### PR TITLE
chore: add SAP security policy and warn about ex6 typo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+<!-- START SAP SECURITY.MD V0.0.1 BLOCK -->
+<!-- Please do not remove the version header, this is needed for automatic updates of the SECURITY.md -->
+# SAP Open Source Security Policy
+
+SAP takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, including our primary [SAP](https://github.com/SAP),[SAP-samples](https://github.com/SAP-samples) ,[SAP-docs](https://github.com/SAP-docs) organizations as well as [our other GitHub organizations and projects](https://opensource.sap.com).
+
+If you believe you have found a security vulnerability in any SAP-owned repository, please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via the SAP Trust Center at [https://www.sap.com/about/trust-center/security/incident-management.html](https://www.sap.com/about/trust-center/security/incident-management.html).
+
+If you prefer to submit via email, please send an email to [secure@sap.com](mailto:secure@sap.com). If possible, encrypt your message with our PGP key; please download it from the [SAP Trust Center](https://www.sap.com/keyblock).
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  - The repository name or URL
+  - Type of issue (buffer overflow, SQL injection, cross-site scripting, etc.)
+  - Full paths of the source file(s) related to the manifestation of the issue
+  - The location of the affected source code (tag/branch/commit or direct URL)
+  - Any particular configuration required to reproduce the issue
+  - Step-by-step instructions to reproduce the issue
+  - Proof-of-concept or exploit code (if possible)
+  - Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Disclosure Guidelines
+
+We like to ask you to follow the [Disclosure Guidelines for SAP Security Advisories](https://wiki.scn.sap.com/wiki/display/PSR/Disclosure+Guidelines+for+SAP+Security+Advisories).
+
+## SAP Internal Response Process
+
+As an SAP employee, please check our internal open source security response process ([go/oss-security-response](https://go.sap.corp/oss-security-response)) for further details on how to handle security incidents.
+
+<!-- END SAP SECURITY.MD V0.0.1 BLOCK -->

--- a/exercises/ex6/README.md
+++ b/exercises/ex6/README.md
@@ -4,6 +4,9 @@ In this exercise you will build your first SAP HANA Calculation View inside Busi
 
 Perform all the steps in 👉 [tutorial: Create Calculation View and Expose via CAP (SAP HANA Cloud)](https://developers.sap.com/tutorials/hana-cloud-cap-calc-view.html)
 
+> [!WARNING]
+> **Heads-up on a screenshot typo in the upstream tutorial.** A couple of screenshots in the tutorial show the artifact name as `V_INTERATION` (missing the second **C**). The correct name — used in the surrounding text, your CDS file, and every later step — is **`V_INTERACTION`**. When you create the Calculation View artifact, type `V_INTERACTION` regardless of what the screenshot shows. (Tracked upstream; this note will be removed once the screenshots are refreshed.)
+
 ## Background
 
 ### What is a Calculation View?


### PR DESCRIPTION
## Summary

Two small but unrelated improvements bundled together (both spawned from a project-health review):

### 1. `SECURITY.md` (new)
Canonical SAP-samples security policy (V0.0.1 from [SAP-samples/.github](https://github.com/SAP-samples/.github/blob/main/SECURITY.md)). Points to the SAP Trust Center for vulnerability reports. The version header lets SAP's tooling auto-update it.

### 2. WARNING callout in [exercises/ex6/README.md](exercises/ex6/README.md) — fixes #32
Two screenshots in the upstream SAP tutorial ([hana-cloud-cap-calc-view](https://developers.sap.com/tutorials/hana-cloud-cap-calc-view.html)) show `V_INTERATION` (missing the second **C**) instead of the correct `V_INTERACTION` — affecting [`create_calc_view.png`](https://github.com/sap-tutorials/Tutorials/blob/master/tutorials/hana-cloud-cap-calc-view/create_calc_view.png) and [`folder_view.png`](https://github.com/sap-tutorials/Tutorials/blob/master/tutorials/hana-cloud-cap-calc-view/folder_view.png).

We can't pixel-edit the upstream PNGs, so this PR adds a `> [!WARNING]` admonition right after the tutorial link in our exercise README. Participants will see the heads-up *before* hitting the typo'd screenshots. The issue reporter explicitly said they trust screenshots more than text — this preempts that trust gap.

A separate upstream issue will be filed against [sap-tutorials/Tutorials](https://github.com/sap-tutorials/Tutorials) so the screenshots get refreshed; once that's done the callout can be removed.

## Context (off-PR)
This branch is also our first PR through the new branch protection ruleset (replaces the legacy classic protection — rule `require_last_push_approval` is now satisfied as required by OSPO before 2026-06-16).

Closes #32