### PR TITLE
chore(deps): patch ws and form-data advisories in approuter

### DIFF
--- a/solution/MyHANAApp/app/router/package-lock.json
+++ b/solution/MyHANAApp/app/router/package-lock.json
@@ -28,14 +28,14 @@
       "license": "MIT"
     },
     "node_modules/@sap/approuter": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@sap/approuter/-/approuter-22.0.1.tgz",
-      "integrity": "sha512-cjbhJFBt4HwVyWwJygPi3yDHZde3/msZ45CG297utzYpNxTxIr0xBylQyl+FuTxtvS0O5efrlPqxzyr5kd6bZg==",
+      "version": "22.0.3",
+      "resolved": "https://registry.npmjs.org/@sap/approuter/-/approuter-22.0.3.tgz",
+      "integrity": "sha512-hjtf23npfT+9qNVZ6URHnhWT2sER8YZfjaxQKSwRl+P7Npu/ySSNSQWnqZvdtiH8PsrB5eBd7tTSNmfxy/n/vA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sap/audit-logging": "7.0.0",
         "@sap/e2e-trace": "6.0.0",
-        "@sap/logging": "9.2.0",
+        "@sap/logging": "9.2.1",
         "@sap/xsenv": "6.0.0",
         "@sap/xssec": "4.12.2",
         "agentkeepalive": "4.6.0",
@@ -148,13 +148,13 @@
       }
     },
     "node_modules/@sap/logging": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@sap/logging/-/logging-9.2.0.tgz",
-      "integrity": "sha512-qy9ADRZdJGMx5HwVvJQAwAWd2JWzO3aTxOaqkodfZB6xa4taMaPJXKgp5l50kguoj/FSh85LxlhS7msJkBoY5Q==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@sap/logging/-/logging-9.2.1.tgz",
+      "integrity": "sha512-ffeyy3T57fMgMGsmvj58K+bXS7b8f3AReICDOGMPwKOUVRtwG0Qm2gCkoMyq+VU0ioQrXKdlLuSy/ZwlIrTjLg==",
       "license": "SEE LICENSE IN LICENSE file",
       "dependencies": {
         "@sap/e2e-trace": "^6.2.1",
-        "lodash": "4.18.01",
+        "lodash": "4.18.1",
         "moment": "2.30.1"
       },
       "engines": {
@@ -974,16 +974,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1640,12 +1640,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1825,9 +1826,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2261,9 +2262,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"

--- a/solution/MyHANAApp/app/router/package.json
+++ b/solution/MyHANAApp/app/router/package.json
@@ -3,6 +3,9 @@
   "dependencies": {
     "@sap/approuter": "^22.0.1"
   },
+  "overrides": {
+    "ws": "^7.5.11"
+  },
   "engines": {
     "node": "^24"
   },


### PR DESCRIPTION
## Summary

Closes two open Dependabot alerts in [solution/MyHANAApp/app/router/](solution/MyHANAApp/app/router/) — follow-up to #40.

| # | Severity | Package | Before | After | How |
| --- | --- | --- | --- | --- | --- |
| [#193](https://github.com/SAP-samples/cap-hana-exercises-codejam/security/dependabot/193) | high | `form-data` | 4.0.5 | **4.0.6** | Lockfile regen |
| [#194](https://github.com/SAP-samples/cap-hana-exercises-codejam/security/dependabot/194) | high | `ws` | 7.5.10 | **7.5.11** | `overrides` |

## Why two different fixes

### form-data — lockfile was stale

The manifest already said `@sap/approuter: ^22.0.1` (bumped by #37) but the lockfile was still pinning `21.5.0` — the bump never got reinstalled. Regenerating `package-lock.json` resolves `@sap/approuter` to **22.0.3** (latest, 8 days old), which transitively pulls `axios 1.16.1` → `form-data 4.0.6`. No manifest change needed for this one.

### ws — needs an explicit override

`@sap/approuter@22.0.3` declares an **exact pin** `"ws": "7.5.10"` (not a caret range). The advisory's fixed version is 7.5.11. Even the latest SAP release hasn't bumped the pin, so npm cannot bring in 7.5.11 transparently. Solution: an [npm `overrides`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides) entry that forces `ws@^7.5.11` for this lockfile.

```json
"overrides": { "ws": "^7.5.11" }
```

7.5.11 is a patch on the same minor line as the pinned 7.5.10 (one commit in the upstream changelog, the GHSA-96hv-2xvq-fx4p mitigation), so the regression risk is very small. This is a temporary workaround until SAP bumps the pin in a future `@sap/approuter` release — worth filing an issue with SAP to nudge that along.

## Verification

- `cd solution/MyHANAApp/app/router && npm install` → `found 0 vulnerabilities`
- Resolved versions:
  ```
  @sap/approuter@22.0.3
  ├─┬ axios@1.16.1
  │ └── form-data@4.0.6
  └── ws@7.5.11
  ```
- `node -e "require('@sap/approuter')"` loads cleanly (no module-resolution errors with the override applied)